### PR TITLE
Add simplejson dependency to addon.xml

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.parsedom" version="0.9.1"/>
+        <import addon="script.module.simplejson" version="3.3.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>


### PR DESCRIPTION
The issue was your code only imports `simplejson` when python < 2.7 and I guess my tv box is a lower version. This could be fixed by just using `json` always as well..or catching the import error and importing json.
